### PR TITLE
Fix report interactions, AI verification, and leaderboard support

### DIFF
--- a/backend/user-module/src/main/java/com/chist/userservice/controller/UserController.java
+++ b/backend/user-module/src/main/java/com/chist/userservice/controller/UserController.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    private final UserRepository userRepository;
 
 
     @GetMapping("/me")
@@ -54,6 +55,20 @@ public class UserController {
         );
     }
 
+
+    @PatchMapping("/internal/{id}/points")
+    public ResponseEntity<?> addPoints(@PathVariable UUID id, @RequestParam int points) {
+        userService.addPoints(id, points);
+        return ResponseEntity.ok(mapToDTO(userService.getUserById(id)));
+    }
+
+    @PatchMapping("/internal/{id}/streak")
+    public ResponseEntity<?> setStreak(@PathVariable UUID id, @RequestParam int streak) {
+        User user = userService.getUserById(id);
+        user.setStreak(streak);
+        userRepository.save(user);
+        return ResponseEntity.ok(mapToDTO(user));
+    }
 
     private UserResponse mapToDTO(User user){
         return UserResponse.builder()

--- a/backend/user-module/src/main/java/com/chist/userservice/security/SecurityConfig.java
+++ b/backend/user-module/src/main/java/com/chist/userservice/security/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/api/users/internal/**").permitAll()
                         .requestMatchers("/api/users/me").authenticated()
                         .requestMatchers("/api/users/leaderboard").authenticated()
                         .requestMatchers("/api/users/all").hasRole("ADMIN")

--- a/frontend/src/components/CleanModal.tsx
+++ b/frontend/src/components/CleanModal.tsx
@@ -6,7 +6,7 @@ import { SEVERITY_META } from "../data/constants.ts";
 import { useApp } from "../context/AppContext.tsx";
 
 interface CleanModalReport {
-  id: number;
+  id: string | number;
   title: string;
   location: string;
   severity: string;

--- a/frontend/src/components/MapContainer.tsx
+++ b/frontend/src/components/MapContainer.tsx
@@ -7,7 +7,7 @@ import type { T, Lang } from "../i18n.ts";
 import "../styles/MapDashboard.css";
 
 interface Report {
-  id: number;
+  id: string | number;
   title: string;
   location: string;
   description: string;
@@ -25,10 +25,10 @@ interface Report {
 
 interface MapContainerProps {
   reports: Report[];
-  selectedId: number | null;
-  onSelectReport: (id: number) => void;
-  onClaim: (id: number) => void;
-  onComplete: (id: number) => void;
+  selectedId: string | number | null;
+  onSelectReport: (id: string | number) => void;
+  onClaim: (id: string | number) => void;
+  onComplete: (id: string | number) => void;
   i: T;
   lang: Lang;
 }

--- a/frontend/src/components/MapDashboard.tsx
+++ b/frontend/src/components/MapDashboard.tsx
@@ -57,7 +57,7 @@ export default function MapDashboard({ onNavigate, currentTab, lang, onToggleLan
   }, [reports, activeFilter, searchQuery]);
 
   const handleSelectReport = useCallback(
-    (id: number) => {
+    (id: string | number) => {
       selectReport(id);
       setMobileOpen(false);
     },

--- a/frontend/src/components/MarkerPopup.tsx
+++ b/frontend/src/components/MarkerPopup.tsx
@@ -5,7 +5,7 @@ import { translateReport } from "../i18n.ts";
 import "../styles/MarkerPopup.css";
 
 interface Report {
-  id: number;
+  id: string | number;
   title: string;
   location: string;
   description: string;
@@ -21,8 +21,8 @@ interface Report {
 
 interface MarkerPopupProps {
   report: Report;
-  onClaim: (id: number) => void;
-  onComplete: (id: number) => void;
+  onClaim: (id: string | number) => void;
+  onComplete: (id: string | number) => void;
   i: T;
   lang: Lang;
 }

--- a/frontend/src/components/ReportCard.tsx
+++ b/frontend/src/components/ReportCard.tsx
@@ -7,7 +7,7 @@ import { t, translateReport } from "../i18n.ts";
 import type { Lang } from "../i18n.ts";
 
 interface ReportData {
-  id: number;
+  id: string | number;
   title: string;
   location: string;
   description?: string;

--- a/frontend/src/components/ReportModal.tsx
+++ b/frontend/src/components/ReportModal.tsx
@@ -86,7 +86,7 @@ function Step1Photo({ data, onChange, onNext }: Step1Props) {
     [onChange],
   );
 
-  const canProceed = data.photoFile && (aiState === "success");
+  const canProceed = data.photoFile && (aiState === "success" || aiState === "error");
 
   return (
     <div className="anim-fade-up">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import { useApp } from "../context/AppContext.tsx";
 import "../styles/MapSidebar.css";
 
 interface Report {
-  id: number;
+  id: string | number;
   title: string;
   location: string;
   severity: string;
@@ -24,8 +24,8 @@ interface SidebarProps {
   onFilterChange: (id: string) => void;
   searchQuery: string;
   onSearchChange: (q: string) => void;
-  selectedId: number | null;
-  onSelectReport: (id: number) => void;
+  selectedId: string | number | null;
+  onSelectReport: (id: string | number) => void;
   mobileOpen: boolean;
   onMobileClose: () => void;
   i: T;

--- a/frontend/src/components/SignalCard.tsx
+++ b/frontend/src/components/SignalCard.tsx
@@ -4,7 +4,7 @@ import { translateReport } from "../i18n.ts";
 import "../styles/SignalCard.css";
 
 interface Report {
-  id: number;
+  id: string | number;
   title: string;
   location: string;
   severity: string;

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -142,7 +142,13 @@ function mapApiReport(data: any): Report {
     district: data.district ?? "София",
     lat: data.latitude ?? 0,
     lng: data.longitude ?? 0,
-    status: data.status?.toLowerCase()?.replace("_", "-") ?? "open",
+    status: (() => {
+      const raw = (data.status ?? "open").toUpperCase();
+      if (raw === "NEW" || raw === "OPEN") return "open";
+      if (raw === "IN_PROGRESS" || raw === "IN-PROGRESS") return "in-progress";
+      if (raw === "COMPLETED" || raw === "DONE") return "done";
+      return "open";
+    })(),
     severity: sev,
     img: "map-pin",
     points: POINTS_BY_SEVERITY[sev] ?? 80,

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -321,9 +321,9 @@ export function translateLevel(_lang: Lang, level: string): string {
   return bg === en ? bg : `${bg} / ${en}`;
 }
 
-export function translateReport(lang: Lang, report: { id: number; title: string; location: string; description?: string }) {
+export function translateReport(lang: Lang, report: { id: string | number; title: string; location: string; description?: string }) {
   if (lang === "bg") return { title: report.title, location: report.location, description: report.description ?? "" };
-  const tr = reportTranslations[report.id];
+  const tr = reportTranslations[report.id as number];
   if (!tr) return { title: report.title, location: report.location, description: report.description ?? "" };
   return tr;
 }

--- a/helm/verification-module-chart/values.yaml
+++ b/helm/verification-module-chart/values.yaml
@@ -27,12 +27,11 @@ service:
 ingress:
   enabled: true
   className: nginx
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  annotations: {}
   hosts:
     - host: "4.165.174.62.nip.io"
       paths:
-        - path: /api/verifications(/|$)(.*)
+        - path: /api/verifications
           pathType: Prefix
   tls: []
 
@@ -48,7 +47,7 @@ livenessProbe:
   httpGet:
     path: /actuator/health
     port: 8083
-  initialDelaySeconds: 90
+  initialDelaySeconds: 120
   periodSeconds: 15
   failureThreshold: 5
 
@@ -56,7 +55,7 @@ readinessProbe:
   httpGet:
     path: /actuator/health
     port: 8083
-  initialDelaySeconds: 90
+  initialDelaySeconds: 120
   periodSeconds: 15
   failureThreshold: 5
 

--- a/scripts/seed-leaderboard.sh
+++ b/scripts/seed-leaderboard.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Seed leaderboard data via internal user-module endpoints
+# Run AFTER merging to main and deploying the internal endpoints
+# Usage: bash scripts/seed-leaderboard.sh
+
+BASE="https://4.165.174.62.nip.io/api/users/internal"
+
+echo "Setting points and streaks for test users..."
+
+# Maria - top user
+curl -sk -X PATCH "$BASE/01526843-6090-43fb-9a46-71c4e1e86c6a/points?points=2450" && echo ""
+curl -sk -X PATCH "$BASE/01526843-6090-43fb-9a46-71c4e1e86c6a/streak?streak=12" && echo ""
+
+# Georgi
+curl -sk -X PATCH "$BASE/e11e8f95-7dd0-406d-adde-e7c5d4e85591/points?points=1820" && echo ""
+curl -sk -X PATCH "$BASE/e11e8f95-7dd0-406d-adde-e7c5d4e85591/streak?streak=7" && echo ""
+
+# Elena
+curl -sk -X PATCH "$BASE/1163f268-1250-433d-9f3f-bafbd63b37b4/points?points=1340" && echo ""
+curl -sk -X PATCH "$BASE/1163f268-1250-433d-9f3f-bafbd63b37b4/streak?streak=5" && echo ""
+
+# Ivan
+curl -sk -X PATCH "$BASE/0f9ee133-b777-44c6-9c36-54a6ff3bdea9/points?points=890" && echo ""
+curl -sk -X PATCH "$BASE/0f9ee133-b777-44c6-9c36-54a6ff3bdea9/streak?streak=3" && echo ""
+
+# Sofia
+curl -sk -X PATCH "$BASE/bed13d9e-eaa5-4c8a-9e54-0ce26f692f2c/points?points=670" && echo ""
+curl -sk -X PATCH "$BASE/bed13d9e-eaa5-4c8a-9e54-0ce26f692f2c/streak?streak=4" && echo ""
+
+# Alex (existing user)
+curl -sk -X PATCH "$BASE/65cda1be-42b4-486f-a39a-60122df5e997/points?points=520" && echo ""
+curl -sk -X PATCH "$BASE/65cda1be-42b4-486f-a39a-60122df5e997/streak?streak=2" && echo ""
+
+# yoshiboshi (existing user)
+curl -sk -X PATCH "$BASE/6809dc89-4ed1-463c-8206-f35d18b15348/points?points=380" && echo ""
+curl -sk -X PATCH "$BASE/6809dc89-4ed1-463c-8206-f35d18b15348/streak?streak=1" && echo ""
+
+# toncho (existing user)
+curl -sk -X PATCH "$BASE/4b21f81b-3f3c-4a22-a2ec-a4c6df6aff65/points?points=210" && echo ""
+
+# iskren (existing user)
+curl -sk -X PATCH "$BASE/3915195a-30f3-45be-8c46-eeefe1196b98/points?points=150" && echo ""
+
+echo "Done! Check the leaderboard at https://4.165.174.62.nip.io"


### PR DESCRIPTION
## Summary
- **Report status mapping**: Backend returns `NEW`/`COMPLETED` but frontend expected `open`/`done` — reports now show claim/complete buttons correctly
- **UUID support**: Changed report `id` type from `number` to `string | number` across all components to support backend UUIDs
- **AI verification bypass**: Allow proceeding with report upload even when Azure Vision says no trash detected
- **Verification endpoint**: Added `POST /api/verifications/check-image` for multipart image upload + nginx route + multipart config
- **Sidebar streak**: Fetches real streak from backend instead of hardcoded `7`
- **Internal points API**: Added `PATCH /api/users/internal/{id}/points` and `/streak` for seeding leaderboard data
- **FormData fix**: `api.ts` no longer sets `Content-Type: application/json` for file uploads
- **10 test reports** created across Sofia for map pins

## Test plan
- [ ] Login and verify reports appear on map with claim buttons
- [ ] Click claim on a report, then complete it — points should update
- [ ] Upload a photo in New Report — should proceed even if AI says no trash
- [ ] Check leaderboard page shows all registered users
- [ ] Run `bash scripts/seed-leaderboard.sh` after deploy to populate leaderboard points

🤖 Generated with [Claude Code](https://claude.com/claude-code)